### PR TITLE
Greatly improved speed for steam game value changes, and bug fix.

### DIFF
--- a/ServerDetailsEditor.cs
+++ b/ServerDetailsEditor.cs
@@ -15,14 +15,26 @@ namespace ServerDetailsEditor
         protected override void Load()
         {
             R.Plugins.OnPluginsLoaded += OnPluginsLoaded;
+            Level.onLevelLoaded += OnLevelLoaded;
         }
 
         protected override void Unload()
         {
             R.Plugins.OnPluginsLoaded -= OnPluginsLoaded;
+            Level.onLevelLoaded -= OnLevelLoaded;
         }
 
         private void OnPluginsLoaded()
+        {
+            UpdateSteamGameServerValues();
+        }
+
+        private void OnLevelLoaded(int level)
+        {
+            UpdateSteamGameServerValues();
+        }
+
+        private void UpdateSteamGameServerValues()
         {
             if (Configuration.Instance.largeServer)
             {

--- a/ServerDetailsEditor.cs
+++ b/ServerDetailsEditor.cs
@@ -14,15 +14,15 @@ namespace ServerDetailsEditor
     {
         protected override void Load()
         {
-            Level.onLevelLoaded += Level_onLevelLoaded;
+            R.Plugins.OnPluginsLoaded += OnPluginsLoaded;
         }
 
         protected override void Unload()
         {
-            Level.onLevelLoaded -= Level_onLevelLoaded;
+            R.Plugins.OnPluginsLoaded -= OnPluginsLoaded;
         }
 
-        private void Level_onLevelLoaded(int level)
+        private void OnPluginsLoaded()
         {
             if (Configuration.Instance.largeServer)
             {


### PR DESCRIPTION
Steam game values will update when plugins are loaded, which is considerably faster then on level loaded.
Bug fix: <rocketPlugins> values will now update on "rocket reload" command, due to using the "plugins loaded" event.